### PR TITLE
Return unmodified version of image if Jetpack is in dev mode.

### DIFF
--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -726,7 +726,7 @@ class WPcom_Thumbnail_Editor {
 
 		list( $selection_x1, $selection_y1, $selection_x2, $selection_y2 ) = $coordinates;
 
-		if( function_exists( 'jetpack_photon_url' ) )
+		if( function_exists( 'jetpack_photon_url' ) &&  !defined('JETPACK_DEV_DEBUG') )
 			$url = jetpack_photon_url(
 				wp_get_attachment_url( $attachment_id ),
 				array(
@@ -743,7 +743,7 @@ class WPcom_Thumbnail_Editor {
 				)
 			);
 		else
-			$url = wp_get_attachment_url( $attachment_id );
+			return $existing_resize;
 
 		return array( $url, $thumbnail_size['width'], $thumbnail_size['height'], true );
 	}

--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -712,6 +712,10 @@ class WPcom_Thumbnail_Editor {
 	 * @return mixed Array of thumbnail details (URL, width, height, is_intermedite) or the previous data.
 	 */
 	public function get_thumbnail_url( $existing_resize, $attachment_id, $size ) {
+		
+		if( !function_exists( 'jetpack_photon_url' ) ||  defined('JETPACK_DEV_DEBUG') )
+			return $existing_resize;
+		
 		// Named sizes only
 		if ( is_array( $size ) )
 			return $existing_resize;
@@ -726,8 +730,7 @@ class WPcom_Thumbnail_Editor {
 
 		list( $selection_x1, $selection_y1, $selection_x2, $selection_y2 ) = $coordinates;
 
-		if( function_exists( 'jetpack_photon_url' ) &&  !defined('JETPACK_DEV_DEBUG') )
-			$url = jetpack_photon_url(
+		$url = jetpack_photon_url(
 				wp_get_attachment_url( $attachment_id ),
 				array(
 					'crop' => array( 
@@ -742,8 +745,6 @@ class WPcom_Thumbnail_Editor {
 					),
 				)
 			);
-		else
-			return $existing_resize;
 
 		return array( $url, $thumbnail_size['width'], $thumbnail_size['height'], true );
 	}


### PR DESCRIPTION
On dev sites, Jetpack is often active but Photon will not work because the content files are not accessible to the public internet. For example, VIP Quickstart dev and staging sites.
Right now, a broken image is displayed when this plugin is active and a thumbnail has been edited. This fix will at least allow the unmodified image to be displayed.
