### PR TITLE
Add additional hooks for extensibility

### DIFF
--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -166,6 +166,7 @@ class WPcom_Thumbnail_Editor {
 			foreach ( $sizes as $key => $size ) {
 
 				$image_name = $this->use_ratio_map ? $key : $size;
+				$image_name = apply_filters( 'wpcom_thumbnail_editor_image_name', $image_name, $this->use_ratio_map );
 
 				$edit_url = admin_url( 'admin.php?action=wpcom_thumbnail_edit&id=' . intval( $attachment->ID ) . '&size=' . urlencode( $size ) );
 
@@ -358,6 +359,8 @@ class WPcom_Thumbnail_Editor {
 
 		<p><img src="<?php echo esc_url( $image[0] ); ?>" width="<?php echo (int) $image[1]; ?>" height="<?php echo (int) $image[2]; ?>" id="wpcom-thumbnail-edit" alt="<?php esc_attr( sprintf( __( '"%s" Thumbnail', 'wpcom-thumbnail-editor' ), $size ) ); ?>" /></p>
 
+		<?php do_action( 'wpcom_thumbnail_editor_edit_thumbnail_screen', $attachment->ID, $size ) ?>
+
 		<p>
 			<?php submit_button( null, 'primary', 'submit', false ); ?>
 			<?php submit_button( __( 'Reset Thumbnail', 'wpcom-thumbnail-editor' ), 'primary', 'wpcom_thumbnail_edit_reset', false ); ?>
@@ -373,7 +376,7 @@ class WPcom_Thumbnail_Editor {
 		<input type="hidden" name="action" value="wpcom_thumbnail_edit" />
 		<input type="hidden" name="id" value="<?php echo (int) $attachment->ID; ?>" />
 		<input type="hidden" name="size" value="<?php echo esc_attr( $size ); ?>" />
-		<?php wp_nonce_field( 'wpcom_thumbnail_edit_' . $attachment->ID . '_' . $size ); ?> 
+		<?php wp_nonce_field( 'wpcom_thumbnail_edit_' . $attachment->ID . '_' . $size ); ?>
 
 		<!--
 			Since the fullsize image is possibly scaled down, we need to record at what size it was
@@ -453,6 +456,9 @@ class WPcom_Thumbnail_Editor {
 
 		// Save the coordinates
 		$this->save_coordinates( $attachment->ID, $size, array( $fullsize_selection_x1, $fullsize_selection_y1, $fullsize_selection_x2, $fullsize_selection_y2 ) );
+
+		// Allow for saving custom fields
+		do_action( 'wpcom_thumbnail_editor_post_handler', $attachment->ID, $size );
 
 		wp_safe_redirect( admin_url( 'media.php?action=edit&attachment_id=' . $attachment->ID . '&wteupdated=1' ) );
 		exit();
@@ -713,24 +719,27 @@ class WPcom_Thumbnail_Editor {
 	 */
 	public function get_thumbnail_url( $existing_resize, $attachment_id, $size ) {
 		// Named sizes only
-		if ( is_array( $size ) )
+		if ( is_array( $size ) ) {
 			return $existing_resize;
+		}
 
 		$coordinates = $this->get_coordinates( $attachment_id, $size );
 
-		if ( ! $coordinates || ! is_array( $coordinates ) || 4 != count( $coordinates ) )
+		if ( ! $coordinates || ! is_array( $coordinates ) || 4 != count( $coordinates ) ) {
 			return $existing_resize;
+		}
 
-		if ( ! $thumbnail_size = $this->get_thumbnail_dimensions( $size ) )
+		if ( ! $thumbnail_size = $this->get_thumbnail_dimensions( $size ) ) {
 			return $existing_resize;
+		}
 
 		list( $selection_x1, $selection_y1, $selection_x2, $selection_y2 ) = $coordinates;
 
-		if( function_exists( 'jetpack_photon_url' ) )
+		if ( function_exists( 'jetpack_photon_url' ) ) {
 			$url = jetpack_photon_url(
 				wp_get_attachment_url( $attachment_id ),
-				array(
-					'crop' => array( 
+				apply_filters( 'wpcom_thumbnail_editor_thumbnail_args', array(
+					'crop' => array(
 						$selection_x1 . 'px',
 						$selection_y1 . 'px',
 						( $selection_x2 - $selection_x1 ) . 'px',
@@ -740,10 +749,11 @@ class WPcom_Thumbnail_Editor {
 						$thumbnail_size['width'],
 						$thumbnail_size['height'],
 					),
-				)
+				), $attachment_id, $thumbnail_size )
 			);
-		else
+		} else {
 			$url = wp_get_attachment_url( $attachment_id );
+		}
 
 		return array( $url, $thumbnail_size['width'], $thumbnail_size['height'], true );
 	}

--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -166,7 +166,7 @@ class WPcom_Thumbnail_Editor {
 			foreach ( $sizes as $key => $size ) {
 
 				$image_name = $this->use_ratio_map ? $key : $size;
-				$image_name = apply_filters( 'wpcom_thumbnail_editor_image_name', $image_name, $this->use_ratio_map );
+				$image_name = apply_filters( 'wpcom_thumbnail_editor_image_name', $image_name, $key, $size, $this->use_ratio_map );
 
 				$edit_url = admin_url( 'admin.php?action=wpcom_thumbnail_edit&id=' . intval( $attachment->ID ) . '&size=' . urlencode( $size ) );
 
@@ -182,7 +182,7 @@ class WPcom_Thumbnail_Editor {
 				if( function_exists( 'jetpack_photon_url' ) ) {
 					$thumbnail_url = jetpack_photon_url(
 						$thumbnail[0],
-						apply_filters( 'wpcom_thumbnail_editor_preview_args', array( 'fit' => array( 250, 250 ) ) )
+						apply_filters( 'wpcom_thumbnail_editor_preview_args', array( 'fit' => array( 250, 250 ) ), $attachment->ID, $size )
 					);
 				} else {
 					$thumbnail_url = $thumbnail[0];
@@ -753,7 +753,7 @@ class WPcom_Thumbnail_Editor {
 						$thumbnail_size['width'],
 						$thumbnail_size['height'],
 					),
-				), $attachment_id, $thumbnail_size )
+				), $attachment_id, $size, $thumbnail_size )
 			);
 		} else {
 			$url = wp_get_attachment_url( $attachment_id );

--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -179,10 +179,14 @@ class WPcom_Thumbnail_Editor {
 				$thumbnail = image_downsize( $attachment->ID, $size );
 
 				// Resize the thumbnail to fit into a small box so it's displayed at a reasonable size
-				if( function_exists( 'jetpack_photon_url' ) )
-					$thumbnail_url = jetpack_photon_url( $thumbnail[0], array( 'fit' => array( 250, 250 ) ) );
-				else
+				if( function_exists( 'jetpack_photon_url' ) ) {
+					$thumbnail_url = jetpack_photon_url(
+						$thumbnail[0],
+						apply_filters( 'wpcom_thumbnail_editor_preview_args', array( 'fit' => array( 250, 250 ) ) )
+					);
+				} else {
 					$thumbnail_url = $thumbnail[0];
+				}
 
 				$html .= '<div style="float:left;margin:0 20px 20px 0;min-width:250px;">';
 					$html .= '<a href="' . esc_url( $edit_url ) . '"';


### PR DESCRIPTION
This pull request adds some additional hooks to allow this plugin to handle custom and probably common use cases:
1. **Control which image sizes are available for resizing**. Some image sizes maybe shouldn't be customized or are just clutter (i.e. CAP image sizes). SEE `wpcom_thumbnail_editor_image_size_names_choose`.
2. **Filter the image size name that displays**. `some-developers-size-name` might not mean much to an editor, but filtering it to `Home Page Hero Image` does. See `wpcom_thumbnail_editor_image_name`.
3. **Control how big the images are displayed on the edit screen**. Small thumbnails are perfect for the modal, but we might want bigger sizes to display on the attachment edit screen. See `wpcom_thumbnail_editor_preview_args`.
4. **Add custom fields**. There are other Photon settings like brightness that could be controlled using the same screen. Let's allow custom fields to be added (`wpcom_thumbnail_editor_edit_thumbnail_screen`) and saved (`wpcom_thumbnail_editor_post_handler`).
5. **Add additional arguments**. And if we save custom values, we should be able to add them to the URL or modify the others. See `wpcom_thumbnail_editor_thumbnail_args`.
