### PR TITLE
Added additional filters to faciliate using custom crops for all sizes

### DIFF
--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -515,7 +515,7 @@ class WPcom_Thumbnail_Editor {
 			add_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );
 		}
 
-		if ( $cropped_only ) {
+		if ( apply_filters( 'wpcom_thumbnail_editor_cropped_only', $cropped_only ) ) {
 			$filtered_sizes = array();
 
 			foreach ( $sizes as $size ) {
@@ -538,7 +538,7 @@ class WPcom_Thumbnail_Editor {
 			$sizes = $filtered_sizes;
 		}
 
-		return $sizes;
+		return apply_filters( 'wpcom_thumbnail_editor_get_intermediate_image_sizes', $sizes, $cropped_only );
 	}
 
 	/**


### PR DESCRIPTION
I found this useful in development to allow for cropping sizes that are soft cropped and not hard cropped. The plugin disables this by default, though the existence of the `cropped_only` variable shows that some thought was given to this. I've made this modifiable to allow for cropping all sizes.
