### PR TITLE
Adding proper check for JETPACK_DEV_DEBUG constant

### DIFF
--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -733,10 +733,11 @@ class WPcom_Thumbnail_Editor {
 	 */
 	public function get_thumbnail_url( $existing_resize, $attachment_id, $size ) {
 		
-		//On dev sites, Jetpack is often active but Photon will not work because the content files are not accessible to the public internet.
-		//Right now, a broken image is displayed when this plugin is active and a thumbnail has been edited. This will allow the unmodified image to be displayed.
-		if( !function_exists( 'jetpack_photon_url' ) ||  defined('JETPACK_DEV_DEBUG') )
+		// On dev sites, Jetpack is often active but Photon will not work because the content files are not accessible to the public internet.
+		// Right now, a broken image is displayed when this plugin is active and a thumbnail has been edited. This will allow the unmodified image to be displayed.
+		if ( ! function_exists( 'jetpack_photon_url' ) || ( true === defined( 'JETPACK_DEV_DEBUG' ) && true === constant( 'JETPACK_DEV_DEBUG' ) ) ) {
 			return $existing_resize;
+		}
 			
 		// Named sizes only
 		if ( is_array( $size ) ) {


### PR DESCRIPTION
We should check whether the constant is set to `true`, not only if it is set, as it can be set to `false` as well and in such case we don't want to behave like the Jetpack is in dev mode.

This commit adds proper check and fixes some coding style violations of touched code (whitespaces, curly brackets in if clause)