### PR TITLE
Provide hooks during imgareaselect documentation

### DIFF
--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -355,9 +355,11 @@ class WPcom_Thumbnail_Editor {
 					onInit: function ( img, selection ) {
 						update_preview( img, selection );
 						$('#wpcom-thumbnail-edit-preview').show();
+                        $.trigger('wpcom_thumbnail_edit_init');
 					},
 					onSelectChange: function ( img, selection ) {
 						update_preview( img, selection );
+                        $.trigger('wpcom_thumbnail_edit_change');
 					},
 
 					// Fill the hidden fields with the selected coordinates for the form
@@ -366,6 +368,7 @@ class WPcom_Thumbnail_Editor {
 						$('input[name="wpcom_thumbnail_edit_y1"]').val(selection.y1);
 						$('input[name="wpcom_thumbnail_edit_x2"]').val(selection.x2);
 						$('input[name="wpcom_thumbnail_edit_y2"]').val(selection.y2);
+                        $.trigger('wpcom_thumbnail_edit_selectend');
 					}
 				});
 			});

--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -355,11 +355,11 @@ class WPcom_Thumbnail_Editor {
 					onInit: function ( img, selection ) {
 						update_preview( img, selection );
 						$('#wpcom-thumbnail-edit-preview').show();
-                        $.trigger('wpcom_thumbnail_edit_init');
+                        $('#wpcom-thumbnail-edit').trigger('wpcom_thumbnail_edit_init');
 					},
 					onSelectChange: function ( img, selection ) {
 						update_preview( img, selection );
-                        $.trigger('wpcom_thumbnail_edit_change');
+                        $('#wpcom-thumbnail-edit').trigger('wpcom_thumbnail_edit_change');
 					},
 
 					// Fill the hidden fields with the selected coordinates for the form
@@ -368,7 +368,7 @@ class WPcom_Thumbnail_Editor {
 						$('input[name="wpcom_thumbnail_edit_y1"]').val(selection.y1);
 						$('input[name="wpcom_thumbnail_edit_x2"]').val(selection.x2);
 						$('input[name="wpcom_thumbnail_edit_y2"]').val(selection.y2);
-                        $.trigger('wpcom_thumbnail_edit_selectend');
+                        $('#wpcom-thumbnail-edit').trigger('wpcom_thumbnail_edit_selectend');
 					}
 				});
 			});


### PR DESCRIPTION
Provide hooks during imgareaselect call so as to make sure that a particular event has been occurred and third party code can extend by making sure that it has been initialised successfully.