### PR TITLE
Add composer.json for projects requiring plugin via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+	"name": "automattic/wpcom-thumbnail-editor",
+	"description": "WordPress.com Thumbnail Editor",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0+"
+}


### PR DESCRIPTION
This PR adds a basic composer.json file which is useful for projects requiring plugins via Composer.