### PR TITLE
Maintain custom crops in `srcset` URLs

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -72,8 +72,16 @@ jobs:
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service
 
+      - name: Set WordPress installation directory
+        run: echo "WP_CORE_DIR=/tmp/wordpress" >> $GITHUB_ENV
+
       - name: Prepare environment for integration tests
         run: composer prepare-ci
+
+      - name: Install Jetpack
+        run: |
+          curl -o /tmp/jetpack.zip https://downloads.wordpress.org/plugin/jetpack.zip
+          unzip /tmp/jetpack.zip -d ${WP_CORE_DIR}/wp-content/plugins
 
       - name: Run integration tests (single site)
         if: ${{ matrix.php != 8.0 }}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,10 +12,16 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
+	update_option(
+		'active_plugins',
+		array(
+			'jetpack/jetpack.php',
+		)
+	);
+
 	require dirname( __FILE__ ) . '/../wpcom-thumbnail-editor.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-require $_tests_dir . '/includes/bootstrap.php';
 
-require dirname( __FILE__ ) . '/wpcom-thumbnail-editor-testcase.php';
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-wpcom-thumbnail-editor-testcase.php
+++ b/tests/test-wpcom-thumbnail-editor-testcase.php
@@ -7,8 +7,8 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		global $wpcom_thumbnail_editor;
-		$this->_toc = $wpcom_thumbnail_editor;
+		global $WPcom_Thumbnail_Editor;
+		$this->_toc = $WPcom_Thumbnail_Editor;
 	}
 
 	/**
@@ -20,6 +20,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 	) {
 		// Prevent Photon from bailing due to environment.
 		add_filter( 'jetpack_photon_development_mode', '__return_false', 999 );
+		add_filter( 'wpcom_thumbnail_editor_photon_is_available', '__return_true' );
 
 		/**
 		 * Mirror VIP Go functionality to simplify testing, otherwise

--- a/tests/wpcom-thumbnail-editor-testcase.php
+++ b/tests/wpcom-thumbnail-editor-testcase.php
@@ -10,4 +10,226 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 		global $wpcom_thumbnail_editor;
 		$this->_toc = $wpcom_thumbnail_editor;
 	}
+
+	/**
+	 * @dataProvider data_provider_maintain_thumbnail_crop_in_srcset
+	 */
+	public function test_maintain_thumbnail_crop_in_srcset(
+		$expected,
+		$input
+	) {
+		// Prevent Photon from bailing due to environment.
+		add_filter( 'jetpack_photon_development_mode', '__return_false', 999 );
+
+		/**
+		 * Mirror VIP Go functionality to simplify testing, otherwise
+		 * `example.com` is used for the Photon host and `ssl=1` query string is
+		 * appended to all URLs.
+		 */
+		add_filter(
+			'jetpack_photon_domain',
+			static function() {
+				return 'https://wpvip.com';
+			}
+		);
+
+		list( $sources, $src ) = $input;
+
+		$this->assertEquals(
+			$expected,
+			$this->_toc->maintain_thumbnail_crop_in_srcset(
+				$sources,
+				[], // Unused argument.
+				$src
+			)
+		);
+	}
+
+	/**
+	 * Data provider to test `::maintain_thumbnail_crop_in_srcset()`
+	 *
+	 * @return array
+	 */
+	public function data_provider_maintain_thumbnail_crop_in_srcset() {
+		$base_url             = 'https://wpvip.com/image.jpg';
+		$crop_string          = '?crop=249px%2C0px%2C4075px%2C2717px';
+		$base_resize_string   = '&resize=100%2C50';
+		$larger_resize_string = '&resize=200%2C100';
+		$width_string         = '&w=100';
+
+		$base_sources = [
+			'url'        => $base_url,
+			'descriptor' => 'w',
+			'value'      => 100,
+		];
+
+		return [
+			'Empty sources'                 => [
+				[],
+				[
+					[],
+					$base_url,
+				],
+			],
+			'No query strings'              => [
+				[
+					$base_sources,
+				],
+				[
+					[
+						$base_sources,
+					],
+					$base_url,
+				],
+			],
+			'No crop strings'               => [
+				[
+					$base_sources,
+				],
+				[
+					[
+						$base_sources,
+					],
+					add_query_arg( 'foo', 'bar', $base_url ),
+				],
+			],
+			'Pixel-density descriptor'      => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'descriptor' => 'x',
+						],
+					),
+				],
+				[
+					[
+						array_replace(
+							$base_sources,
+							[
+								'descriptor' => 'x',
+							],
+						),
+					],
+					$base_url . $crop_string,
+				],
+			],
+			'Already cropped'               => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'url' => $base_url . $crop_string,
+						],
+					),
+				],
+				[
+					[
+						array_replace(
+							$base_sources,
+							[
+								'url' => $base_url . $crop_string,
+							],
+						),
+					],
+					$base_url . $crop_string,
+				],
+			],
+			'Crop added'                    => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'url' => $base_url . $crop_string . $base_resize_string,
+						],
+					),
+				],
+				[
+					[
+						$base_sources,
+					],
+					$base_url . $crop_string . $base_resize_string,
+				],
+			],
+			'Crop and width added'          => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'url' => $base_url . $crop_string . $larger_resize_string . $width_string,
+						],
+					),
+				],
+				[
+					[
+						$base_sources,
+					],
+					$base_url . $crop_string . $larger_resize_string,
+				],
+			],
+			'Crop added and fit removed'    => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'url' => $base_url . $crop_string . $base_resize_string,
+						],
+					),
+				],
+				[
+					[
+						array_replace(
+							$base_sources,
+							[
+								'url' => $base_url . '?fit=50%2C50',
+							]
+						),
+					],
+					$base_url . $crop_string . $base_resize_string,
+				],
+			],
+			'Crop added, quality unchanged' => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'url' => $base_url . $crop_string . $base_resize_string . '&quality=75',
+						],
+					),
+				],
+				[
+					[
+						array_replace(
+							$base_sources,
+							[
+								'url' => $base_url . '?quality=75',
+							]
+						),
+					],
+					$base_url . $crop_string . $base_resize_string,
+				],
+			],
+			'Fit loses width'               => [
+				[
+					array_replace(
+						$base_sources,
+						[
+							'url' => $base_url . $crop_string . '&fit=50%2C50',
+						],
+					),
+				],
+				[
+					[
+						array_replace(
+							$base_sources,
+							[
+								'url' => $base_url . '?fit=50%2C50' . $width_string,
+							]
+						),
+					],
+					$base_url . $crop_string,
+				],
+			],
+		];
+	}
 }

--- a/tests/wpcom-thumbnail-editor-testcase.php
+++ b/tests/wpcom-thumbnail-editor-testcase.php
@@ -99,7 +99,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'descriptor' => 'x',
-						],
+						]
 					),
 				],
 				[
@@ -108,7 +108,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 							$base_sources,
 							[
 								'descriptor' => 'x',
-							],
+							]
 						),
 					],
 					$base_url . $crop_string,
@@ -120,7 +120,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'url' => $base_url . $crop_string,
-						],
+						]
 					),
 				],
 				[
@@ -129,7 +129,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 							$base_sources,
 							[
 								'url' => $base_url . $crop_string,
-							],
+							]
 						),
 					],
 					$base_url . $crop_string,
@@ -141,7 +141,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'url' => $base_url . $crop_string . $base_resize_string,
-						],
+						]
 					),
 				],
 				[
@@ -157,7 +157,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'url' => $base_url . $crop_string . $larger_resize_string . $width_string,
-						],
+						]
 					),
 				],
 				[
@@ -173,7 +173,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'url' => $base_url . $crop_string . $base_resize_string,
-						],
+						]
 					),
 				],
 				[
@@ -194,7 +194,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'url' => $base_url . $crop_string . $base_resize_string . '&quality=75',
-						],
+						]
 					),
 				],
 				[
@@ -215,7 +215,7 @@ class WPCOMThumbnailEditor_TestCase extends WP_UnitTestCase {
 						$base_sources,
 						[
 							'url' => $base_url . $crop_string . '&fit=50%2C50',
-						],
+						]
 					),
 				],
 				[

--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -1,7 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Plugin Name:  WordPress.com Thumbnail Editor
- * Version:      1.0.0
+ * Version:      1.0.1
  * Description:  Since thumbnails are generated on-demand on WordPress.com, thumbnail cropping location must be set via the URL. This plugin assists in doing this. Based on concepts by Imran Nathani of <a href="http://metronews.ca/">Metro News Canada</a>.
  * Author:       Automattic
  * Author URI:   https://wpvip.com/


### PR DESCRIPTION
`wp_calculate_image_srcset()` does not call the `image_downsize()` function that this plugin filters, preventing `srcset` URLs from honoring custom crops.

Fixes #10.